### PR TITLE
Waiter Feedback

### DIFF
--- a/src/states_registers.jl
+++ b/src/states_registers.jl
@@ -23,11 +23,13 @@ struct Register # TODO better type description
     tag_info::Dict{Int128, @NamedTuple{tag::Tag, slot::Int, time::Float64}}
     guids::Vector{Int128}
     netparent::Ref{Any}
+    waiters::Dict{Tag, Dict{Tuple{Function, Vararg{Any}}, Vector{Store{1, Any}}}}
 end
 
 function Register(traits, reprs, bg, sr, si, at)
     env = ConcurrentSim.Simulation()
-    Register(traits, reprs, bg, sr, si, at, [ConcurrentSim.Resource(env) for _ in traits], Dict{Int128, Tuple{Tag, Int64, Float64}}(), [], nothing)
+    Register(traits, reprs, bg, sr, si, at, [ConcurrentSim.Resource(env) for _ in traits], Dict{Int128, Tuple{Tag, Int64, Float64}}(), [], nothing, Dict{Tag, Dict{Tuple{Function, Vararg{Any}}, []}}()
+    )
 end
 
 Register(traits,reprs,bg,sr,si) = Register(traits,reprs,bg,sr,si,zeros(length(traits)))


### PR DESCRIPTION
This is mostly proof-of-concept to make sure that I'm on the right track. The main idea is to create an empty resource (Store from ConcurrentSim) when condition is not met, followed by !take. This information is saved in waiters field in register, and !tag (and !untag) checks whether relevant conditions are met after tag has been changed, and push the corresponding qbit (slot).

Here are a few questions/problems that I wanted to address:

How expensive is it to make a query? Currently, waiters is a nested dictionary; the keys are tags, and the values are dictionaries mapping tuples of queries (functions) and their arguments to lists of Stores waiting on those queries. I wanted to minimize the number of queries made by only checking ones that are relevant to the tag that is being changed. Using a lock instead of a Store might be beneficial since only one lock would be needed per query, though I think this approach would require re-running the query.

In the example protocol, saving the query along with its arguments feels a bit awkward. I wanted to implement something that could handle any queries, but I think since prot is not accessible in tag! , passing the arguments directly isn't possible. Implementing this waiter feature for specific tags (the ones in current protocols) might be easier. Do you think this is the right direction?

As I'm relatively new to Julia, I realize my syntax may be incorrect or awkward. I expect to resolve most of these issues once I can run the code, but I'd appreciate any feedback on obvious mistakes or good practices I might be missing.

Thanks a lot for your help!